### PR TITLE
Add Gitpod support

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,7 @@
+FROM gitpod/workspace-postgres
+
+USER gitpod
+
+RUN wget https://storage.googleapis.com/dart-archive/channels/stable/release/2.6.1/sdk/dartsdk-linux-x64-release.zip && \
+    unzip dartsdk-linux-x64-release.zip && \
+    echo 'export PATH=$PATH:/home/gitpod/dart-sdk/bin' >>~/.bashrc

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,28 @@
+image:
+  file: .gitpod.Dockerfile
+
+# List the ports you want to expose and what to do when they are served. See https://www.gitpod.io/docs/43_config_ports/
+ports:
+  - port: 9001
+    onOpen: ignore
+  - port: 5432 
+    onOpen: ignore
+
+# List the start up tasks. You can start them in parallel in multiple terminals. See https://www.gitpod.io/docs/44_config_start_tasks/
+tasks:
+  - before: ./db_create.sh
+    init: pub install
+    command: dart bin/server.dart
+  - command: >
+      gp await-port 9001 &&
+      printf "\nadding two items\n----------------\n" &&
+      curl -X POST localhost:9001/item -d '{"name":"my item"}' &&
+      curl -X POST localhost:9001/item -d '{"name":"another item"}' &&
+      printf "\n\nfetching items\n----------------\n" &&
+      curl localhost:9001/items &&
+      printf "\n"
+    openMode: split-right
+
+vscode:
+  extensions:
+    - Dart-Code.dart-code@3.6.0:OIKJQXmfWHoIMVCiWrcLsQ==

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Setup Automated](https://img.shields.io/badge/setup-automated-blue?logo=gitpod)](https://gitpod.io/from-referrer/)
 # dart-postgres-example
 Example project demonstrating how to build web APIs with [Dart](https://dart.dev), [Shelf](https://pub.dartlang.org/packages/shelf), and [PostgreSQL](https://postgresql.org).
 
@@ -16,6 +17,10 @@ To run and test the server:
 * Run the server with `$ dart bin/server.dart`
 * Create items with `$ curl -X POST localhost:9001/item -d '{"name":"test"}'`
 * List items with `$ curl localhost:9001/items`
+
+You can open this project in a free and ready-to-code Gitpod dev environment.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
 
 ## Contribution
 If you notice something out of place or in need of some improvements: issues, pull requests, and other contributions are welcome.


### PR DESCRIPTION
Thanks for the cool post on medium. I gave it a shot with Gitpod (I'm working on it) and it worked so well, that I thought you might want to use it to make it simpler getting your readers started.

I configured it so, that it opens two terminal left and right where on the left the server process runs and on the right you run the curl commands that add items and fetches them again.

<img width="1509" alt="Screenshot 2019-11-25 at 08 55 23" src="https://user-images.githubusercontent.com/372735/69522468-c2a41900-0f61-11ea-9241-6bd68300393b.png">

How it works: You can open a gitpod dev environment on any branch or pr on github. Just prefix the url with `https://gitpod.io#, e.g. https://gitpod.io#https://github.com/svenefftinge/dart-postgres-example. To get the best experience a bit of project-specific configuration is useful (i.e. installing dart SDK and the Dart VS Code extension).
